### PR TITLE
Fix message body selection & parsing

### DIFF
--- a/src/fetcher/main.rs
+++ b/src/fetcher/main.rs
@@ -85,10 +85,6 @@ fn main() -> Result<SysexitsError, Box<dyn Error>> {
                 },
                 "cli" | "mime" | _ => {
                     print!("{}", message.headers.mime());
-                    if let Some(body) = message.body {
-                        println!();
-                        print!("{}", body);
-                    }
                 },
             }
             Ok(EX_OK)

--- a/src/message.rs
+++ b/src/message.rs
@@ -23,11 +23,9 @@ impl TryFrom<&Fetch<'_>> for ImapMessage {
                 let message = MessageParser::default()
                     .parse(bytes)
                     .ok_or(ImapError::InvalidMessage)?;
-                
                 let headers: EmailMessage = (&message)
                     .try_into()
                     .map_err(|_| ImapError::InvalidHeaders)?;
-                
                 Self {
                     pos: input.message as _,
                     uid: input.uid,

--- a/src/message.rs
+++ b/src/message.rs
@@ -23,14 +23,17 @@ impl TryFrom<&Fetch<'_>> for ImapMessage {
                 let message = MessageParser::default()
                     .parse(bytes)
                     .ok_or(ImapError::InvalidMessage)?;
+                
+                let headers: EmailMessage = (&message)
+                    .try_into()
+                    .map_err(|_| ImapError::InvalidHeaders)?;
+                
                 Self {
                     pos: input.message as _,
                     uid: input.uid,
                     size: input.size,
-                    headers: (&message)
-                        .try_into()
-                        .map_err(|_| ImapError::InvalidHeaders)?,
-                    body: message.body_text(0).map(|s| s.into_owned()),
+                    headers: headers.clone(),
+                    body: headers.body,
                 }
             },
             None => {

--- a/src/message.rs
+++ b/src/message.rs
@@ -26,12 +26,13 @@ impl TryFrom<&Fetch<'_>> for ImapMessage {
                 let headers: EmailMessage = (&message)
                     .try_into()
                     .map_err(|_| ImapError::InvalidHeaders)?;
+                let body = headers.body.clone();
                 Self {
                     pos: input.message as _,
                     uid: input.uid,
                     size: input.size,
-                    headers: headers.clone(),
-                    body: headers.body,
+                    headers,
+                    body,
                 }
             },
             None => {


### PR DESCRIPTION
## Summary
Fixed email output duplication issue by removing redundant body extraction.

## Problem
The email body was being extracted twice - once during `know` library conversion and again manually with `message.body_text(0)`, causing duplicate content in the output.

## Solution
Removed manual body extraction and now use the body already included in `EmailMessage` from the library conversion.
